### PR TITLE
Introduce PHP file mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "catenary-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/src/bridge/document_manager.rs
+++ b/src/bridge/document_manager.rs
@@ -215,6 +215,7 @@ fn detect_language_id(path: &Path) -> &'static str {
         Some("css") => "css",
         Some("lua") => "lua",
         Some("sql") => "sql",
+        Some("php") => "php",
         _ => "plaintext",
     }
 }
@@ -328,6 +329,7 @@ mod tests {
         assert_eq!(detect_language_id(Path::new("test.go")), "go");
         assert_eq!(detect_language_id(Path::new("test.sh")), "shellscript");
         assert_eq!(detect_language_id(Path::new("test.bash")), "shellscript");
+        assert_eq!(detect_language_id(Path::new("test.php")), "php");
         assert_eq!(detect_language_id(Path::new("test.unknown")), "plaintext");
         assert_eq!(detect_language_id(Path::new("noextension")), "plaintext");
     }


### PR DESCRIPTION
Hello there!

I have implemented a fix for: https://github.com/MarkWells-Dev/Catenary/issues/8

It was a simply missing a mapping.

I have tested the changes on a PHP Project:

```sh
➜ echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"lsp_document_symbols","arguments":{"file":"./source/engine/Shopware/Application.php"}}}' | catenary --config ~/.config/catenary/config.toml
```

> For some reason it was not picking up my global Catenary config, so I had to pass it as an argument.

Output:
```
2026-02-06T20:45:29.022444Z  INFO catenary: Starting catenary multiplexing bridge
2026-02-06T20:45:29.022458Z  INFO catenary: Session ID: 34b3de3d35b7387
2026-02-06T20:45:29.022460Z  INFO catenary: Workspace root: ~/project
2026-02-06T20:45:29.022462Z  INFO catenary: Document idle timeout: 300s
2026-02-06T20:45:29.022532Z  INFO catenary_mcp::mcp::server: MCP server starting, waiting for requests on stdin
2026-02-06T20:45:29.022594Z  INFO catenary_mcp::lsp::manager: Spawning LSP server for php: devsense-php-ls
{"jsonrpc":"2.0","id":2,"result":{"content":[{"text":"Shopware [Class] line 33\n  Acl() [Method] line 292\n\n  App() [Method] line 114\n\n  AppPath() [Method] line 168\n\n  BackendSession() [Method] line 284\n\n  Bootstrap() [Method] line 362\n\n  Config() [Method] line 232\n\n  Container() [Method] line 178\n\n  Db() [Method] line 260\n\n  DocPath() [Method] line 156\n\n  Environment() [Method] line 128\n\n  Events() [Method] line 332\n\n  Front() [Method] line 216\n\n  Hooks() [Method] line 194\n\n  Loader() [Method] line 186\n\n  Models() [Method] line 268\n\n  Modules() [Method] line 242\n\n  normalizePath() [Method] line 375\n\n  OldPath() [Method] line 142\n\n  PasswordEncoder() [Method] line 324\n\n  Plugins() [Method] line 308\n\n  Session() [Method] line 276\n\n  setEventManager() [Method] line 348\n\n  Shop() [Method] line 250\n\n  Snippets() [Method] line 316\n\n  System() [Method] line 206\n\n  Template() [Method] line 224\n\n  TemplateMail() [Method] line 300\n\n  __call() [Method] line 90\n\n  __construct() [Method] line 66\n\n  appPath [Field] line 51\n\n  container [Field] line 61\n\n  docPath [Field] line 56\n\n  REVISION [Constant] line 46\n\n  VERSION [Constant] line 44\n\n  VERSION_TEXT [Constant] line 45\n\nShopware() [Function] line 394\n","type":"text"}]}}
2026-02-06T20:45:30.069036Z  INFO catenary_mcp::mcp::server: MCP server shutting down (stdin closed)
2026-02-06T20:45:30.069109Z  INFO catenary: Shutting down LSP servers
```