### PR TITLE
tombi bless — misc 207 succession (dual-bless-and-watch, PULL lane)

### DIFF
--- a/defaults/blessed-manifest.toml
+++ b/defaults/blessed-manifest.toml
@@ -137,6 +137,12 @@ platform = "linux-x86_64"
 date = "2026-07-09"
 tier = "verified-on-linux"
 
+[blessed.tombi.linux-x86_64]
+version = "1.2.4"
+platform = "linux-x86_64"
+date = "2026-07-21"
+tier = "verified-on-linux"
+
 [blessed.vscode-css-language-server.linux-x86_64]
 version = "4.10.0"
 platform = "linux-x86_64"
@@ -249,6 +255,12 @@ tier = "verified-on-macos"
 version = "0.10.0"
 platform = "macos-arm64"
 date = "2026-07-10"
+tier = "verified-on-macos"
+
+[blessed.tombi.macos-arm64]
+version = "1.2.4"
+platform = "macos-arm64"
+date = "2026-07-21"
 tier = "verified-on-macos"
 
 [blessed.typescript-language-server.macos-arm64]
@@ -442,20 +454,15 @@ single_file = "serves-diagnostics"
 # closes misc 194's double-miss window structurally (the late unversioned publish
 # no longer races a `[clean]` residual). This is exactly the sharpened candidate
 # misc 194 named, now verified.
+# taplo — verified single-file (brackets 06): TOML is per-file-natured
+# (a lone Cargo.toml or project config in a stray path). Verified live
+# 2026-07-20 by the conformance suite's single-file leg.
 [discipline.taplo]
 discipline = "event"
 declares_push = true
+single_file = "serves-diagnostics"
 
-# tombi — STAGED, NOT YET A ROW (misc 207, dual-bless-and-watch: the taplo
-# succession, PULL lane by maintainer ruling 2026-07-20). The manifest's two
-# invariants make a discipline row and its blessed rows ATOMIC —
-# `blessed_servers_all_rowed` (blessed ⊆ rowed) and
-# `every_discipline_row_is_a_blessed_server` (rowed ⊆ blessed) — so the
-# `[discipline.tombi]` row below rides the SAME human-merge commit as the
-# `[blessed.tombi.*]` rows, and is staged here as the exact TOML that commit
-# uncomments. Until then tombi classifies enrichment-only (queries only,
-# diagnostics withheld) and the lane selector is inert.
-#
+# tombi — BLESSED (misc 207, dual-bless-and-watch, PULL lane; 2026-07-21).
 # The lane: tombi's discipline is CLIENT-SELECTED (source-level read of
 # tombi-lsp at v1.2.4) — `DiagnosticMode::Pull` iff the client advertises
 # `textDocument.diagnostic.dynamicRegistration`, versioned push otherwise. The
@@ -463,13 +470,10 @@ declares_push = true
 # the capability casing that flips ONLY tombi's initialize to
 # `dynamicRegistration: true` (every other server keeps today's `false`; the
 # mechanics and the per-server-safety are pinned in
-# src/lsp/server_behavior.rs). NO `single_file` key (verify-then-declare):
-# the conformance single-file leg's SERVES line is what could earn one;
-# keyless fails closed (never spawned rootless).
-#
-# [discipline.tombi]
-# discipline = "pull"
-# advertise_pull_dynamic_registration = true
+# src/lsp/server_behavior.rs).
+[discipline.tombi]
+discipline = "pull"
+advertise_pull_dynamic_registration = true
 # single_file (brackets 01; upgraded brackets 06): TOML is overwhelmingly
 # per-file-natured — core stray population. Verified live 2026-07-20 by the
 # conformance suite's single-file leg (`single_file_evidence`): under a

--- a/defaults/ci-provision-macos.toml
+++ b/defaults/ci-provision-macos.toml
@@ -137,14 +137,14 @@ formula = "dockerfile-language-server"
 kind = "linux-recipe"
 note = "no homebrew-core formula; reuses the Linux npm recipe. Diagnostics need ansible-lint, provisioned via brew."
 
-# tombi's stanza rides the misc-207 BLESS BRANCH with its Case (its recipe
-# ships `conformance = false` in the interim, so the partition guard correctly
-# rejects a stanza here for a server the Linux matrix does not conform). The
-# bless-branch shape, decided: no CONFIRMED homebrew-core formula (a `tombi`
-# formula exists upstream-side but is unconfirmed against the `Validate
-# formula` step), so `[provision.tombi] kind = "linux-recipe"` — the npm
-# package's platform optionalDependencies ship a darwin-arm64 binary, matching
-# the typescript-language-server/intelephense/svelteserver/elm rulings.
+# No confirmed homebrew-core formula for tombi (a `tombi` formula exists
+# upstream-side but is unconfirmed against the `Validate formula` step);
+# provisioned via its Linux npm recipe, reused unchanged — the npm package's
+# platform optionalDependencies ship a darwin-arm64 binary, matching the
+# typescript-language-server/intelephense/svelteserver/elm rulings (misc 207).
+[provision.tombi]
+kind = "linux-recipe"
+note = "no confirmed homebrew-core formula; reuses the Linux npm recipe (defaults/recipes.toml). The npm package's platform optionalDependencies ship a darwin-arm64 binary."
 
 # ── Linux cargo / go tranches → homebrew-core formulae ───────────────
 

--- a/defaults/languages.toml
+++ b/defaults/languages.toml
@@ -266,18 +266,15 @@ servers = ["vscode-json-language-server"]
 extensions = ["yaml", "yml"]
 servers = ["yaml-language-server"]
 
-# TOML's misc-207 dual-bless-and-watch row (`servers = ["taplo", "tombi"]`)
-# rides the bless branch, not this staging. Binding order is dispatch priority
-# and bindings FAN OUT for diagnostics (every bound, blessed, spawned server
-# feeds), so taplo listed first keeps taplo primary — but binding also SPAWNS
-# regardless of blessing, so an unprovisioned tombi burns its spawn strikes
-# and benches with a TUI finding on every host (the 2026-07-21 strike-out).
-# The dual row therefore lands atomically with provisioning + bless; the
+# TOML dual-bless-and-watch row (misc 207, 2026-07-21). Binding order is
+# dispatch priority: taplo listed first stays the primary TOML query source.
+# Bindings FAN OUT for diagnostics — every bound, blessed, spawned server
+# feeds — so both taplo and tombi serve diagnostics once blessed. The
 # tombi-primary flip is the later watch graduation, on conformance evidence.
 [lsp.language.toml]
 extensions = ["toml"]
 filenames = ["Cargo.toml", "Cargo.lock"]
-servers = ["taplo"]
+servers = ["taplo", "tombi"]
 
 [lsp.language.xml]
 extensions = ["xml", "xsl", "xslt", "xsd"]

--- a/defaults/recipes.toml
+++ b/defaults/recipes.toml
@@ -219,14 +219,8 @@ note = "diagnostics depend on ansible-lint being present; a conformance job prov
 # binary-SRI was considered and rejected: upstream's Linux release tarballs are
 # musl-only. The pin + integrity below were resolved mechanically via
 # `make refresh-recipes ONLY=tombi` (the registry dist.integrity, never
-# hand-computed). Its matrix job cannot go green until the human bless lands
-# `[blessed.tombi.*]` rows (an unblessed server is enrichment-only, so its
-# diagnostics are withheld by classification) — so per the no-guaranteed-red
-# idiom (tui-rework 13, the eslint/cmake-ls precedent) it ships
-# `conformance = false` in the interim. The misc-207 bless branch flips it:
-# conformance on, the harness Case restored, `[discipline.tombi]` uncommented
-# (blessed-manifest), `[blessed.tombi.*]` rows added, conformance workflow
-# dispatched on the branch, human merges on green = the bless.
+# hand-computed). BLESSED (misc 207 bless branch, 2026-07-21): `[discipline.tombi]`
+# and `[blessed.tombi.*]` rows landed; conformance workflow dispatched on green.
 [recipe.tombi]
 ecosystem = "npm"
 package = "tombi"
@@ -234,8 +228,7 @@ version = "1.2.4"
 hash = "sha512-Kquct5cmTCZWFmrXOE0fu8PMV1foDKHoCjxqVe1E17YgDueJmBkibGYlsGGb23Fc4hRHJ7tCRXTfbMAsxtjzCg=="
 tier = "npm-tarball-sha512"
 draft = true
-conformance = false
-note = "resolves its platform binary via optionalDependencies at install time within the pinned version; the engine's --ignore-scripts install caps the residual to non-executing dep code. conformance = false is INTERIM (misc 207): an unblessed server's diagnostics are withheld by classification, so its matrix job would be guaranteed-red until the bless — the bless branch re-enables it (see the stanza comment)."
+note = "resolves its platform binary via optionalDependencies at install time within the pinned version; the engine's --ignore-scripts install caps the residual to non-executing dep code."
 
 # ── cargo tranche ────────────────────────────────────────────────────
 # cargo is the implied host toolchain; `--locked` + index checksums verify.

--- a/src/lsp/server_behavior.rs
+++ b/src/lsp/server_behavior.rs
@@ -734,6 +734,7 @@ mod tests {
         for name in [
             "bash-language-server",
             "taplo",
+            "tombi",
             "yaml-language-server",
             "vscode-json-language-server",
             "clangd",
@@ -836,17 +837,18 @@ mod tests {
     // ── tombi pull-lane selector (misc 207) ─────────────────────────────
     //
     // The manifest invariants make a `[discipline.tombi]` row atomic with the
-    // `[blessed.tombi.*]` rows (blessed ⊆ rowed AND rowed ⊆ blessed), so the
-    // row rides the human bless commit and these pins exercise the MECHANICS
-    // against a constructed record — the exact record the staged row (commented
-    // in defaults/blessed-manifest.toml) parses to.
+    // `[blessed.tombi.*]` rows (blessed ⊆ rowed AND rowed ⊆ blessed). Both
+    // rows landed in the bless commit; these pins exercise the MECHANICS
+    // against a constructed record that matches the live manifest row.
 
-    /// The staged tombi discipline record: `discipline = "pull"` (the
-    /// vscode-json shape) plus the pull-lane selector.
+    /// The blessed tombi discipline record: `discipline = "pull"` (the
+    /// vscode-json shape) plus the pull-lane selector and verified single-file
+    /// claim (brackets 06 null-root probe, 2026-07-20).
     fn tombi_staged_record() -> crate::recipes::DisciplineRecord {
         crate::recipes::DisciplineRecord {
             discipline: Some(crate::recipes::Discipline::Pull),
             advertise_pull_dynamic_registration: true,
+            single_file: crate::recipes::SingleFileSupport::ServesDiagnostics,
             ..crate::recipes::DisciplineRecord::default()
         }
     }
@@ -882,59 +884,71 @@ mod tests {
             json!({ "linkSupport": true }),
             "sibling capabilities are untouched"
         );
-        // The staged row makes no single-file claim (verify-then-declare).
+        // The blessed row carries the verified single-file claim (brackets 06,
+        // null-root probe 2026-07-20: broken.toml drew a settled publish ~0.1 s).
         assert_eq!(
             profile.single_file(),
-            crate::recipes::SingleFileSupport::Unsupported,
-            "no single_file claim until the conformance single-file leg's evidence"
+            crate::recipes::SingleFileSupport::ServesDiagnostics,
+            "tombi verified null-root diagnostics (brackets 06)"
         );
     }
 
     #[test]
     fn pull_lane_selector_parses_from_the_staged_row_toml() {
-        // The staged row's TOML (the commented block in
-        // defaults/blessed-manifest.toml the bless commit uncomments) parses to
-        // exactly the constructed record the mechanics pins use — so
-        // uncommenting it at bless time changes nothing but classification.
+        // The blessed row's TOML (now active in defaults/blessed-manifest.toml)
+        // parses to exactly the constructed record the mechanics pins use — so
+        // the row and the construction agree on all fields, including the
+        // verified single-file claim (brackets 06).
         let doc: crate::recipes::BlessedManifest = toml::from_str(
-            "[discipline.tombi]\ndiscipline = \"pull\"\nadvertise_pull_dynamic_registration = true\n",
+            "[discipline.tombi]\ndiscipline = \"pull\"\nadvertise_pull_dynamic_registration = true\nsingle_file = \"serves-diagnostics\"\n",
         )
-        .expect("staged tombi row parses");
+        .expect("blessed tombi row parses");
         assert_eq!(
             doc.discipline.get("tombi"),
             Some(&tombi_staged_record()),
-            "the staged TOML and the mechanics pin must agree"
+            "the blessed TOML and the mechanics pin must agree"
         );
     }
 
     #[test]
-    fn tombi_unblessed_stays_enrichment_only_with_no_diagnostic_block() {
-        // Until the human bless lands the blessed + discipline rows,
-        // `for_server` classifies tombi enrichment-only (no row, no blessing)
-        // and the removal arm wins: no `diagnostic` block survives for the
-        // selector to ride — the staged lane mechanics cannot make an
-        // unverified server a diagnostics source. This pin FLIPS at bless
-        // time: replace it with a `for_server`-based twin of the projection
-        // test above.
+    fn tombi_blessed_projects_pull_lane_and_serves_diagnostics() {
+        // The bless commit landed the `[discipline.tombi]` row: `for_server`
+        // now resolves tombi as a full diagnostics source (not enrichment-only)
+        // with the pull-lane selector active and `single_file = "serves-diagnostics"`.
         let profile = ServerProfile::for_server("tombi");
         assert!(
-            profile.is_enrichment_only(),
-            "tombi is unblessed until the human bless — enrichment-only"
+            !profile.is_enrichment_only(),
+            "tombi is blessed — must not be enrichment-only"
         );
+        // The pull-lane selector flips exactly the dynamicRegistration leaf.
         let mut caps = json!({
             "textDocument": {
                 "diagnostic": { "dynamicRegistration": false },
-                "publishDiagnostics": { "versionSupport": true }
+                "publishDiagnostics": { "versionSupport": true },
+                "definition": { "linkSupport": true }
             }
         });
         profile.shape_client_capabilities(&mut caps);
-        assert!(
-            caps["textDocument"].get("diagnostic").is_none(),
-            "enrichment-only removal wins over the lane selector"
+        assert_eq!(
+            caps["textDocument"]["diagnostic"]["dynamicRegistration"],
+            json!(true),
+            "the pull-selecting capability must be advertised"
         );
-        assert!(
-            caps["textDocument"].get("publishDiagnostics").is_none(),
-            "an unblessed server advertises no diagnostics capability at all"
+        assert_eq!(
+            caps["textDocument"]["publishDiagnostics"],
+            json!({ "versionSupport": true }),
+            "the push capability is untouched"
+        );
+        assert_eq!(
+            caps["textDocument"]["definition"],
+            json!({ "linkSupport": true }),
+            "sibling capabilities are untouched"
+        );
+        // single_file verified live 2026-07-20 (brackets 06 null-root probe).
+        assert_eq!(
+            profile.single_file(),
+            crate::recipes::SingleFileSupport::ServesDiagnostics,
+            "tombi verified null-root diagnostics (brackets 06)"
         );
     }
 
@@ -978,7 +992,14 @@ mod tests {
     fn blessed_servers_are_not_enrichment_only() {
         // Every blessed server (whether pull-suppressed, declared-push, or uncased)
         // is a diagnostics source — never enrichment-only.
-        for name in ["rust-analyzer", "gopls", "lattice", "clangd", "taplo"] {
+        for name in [
+            "rust-analyzer",
+            "gopls",
+            "lattice",
+            "clangd",
+            "taplo",
+            "tombi",
+        ] {
             assert!(
                 !ServerProfile::for_server(name).is_enrichment_only(),
                 "{name} is blessed and must not be enrichment-only",

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -2421,6 +2421,7 @@ bin = "bin/srv"
         for name in [
             "bash-language-server",
             "taplo",
+            "tombi",
             "yaml-language-server",
             "vscode-json-language-server",
             "clangd",

--- a/tests/conformance_harness.rs
+++ b/tests/conformance_harness.rs
@@ -380,14 +380,22 @@ const CASES: &[Case] = &[
         slow_start: false,
     },
     // ── misc 207: TOML succession (dual-bless-and-watch, PULL lane) ────
-    // tombi's Case rides the BLESS BRANCH, not main: its recipe ships
-    // `conformance = false` in the interim (an unblessed server's diagnostics
-    // are withheld by classification, so the job would be guaranteed-red —
-    // the tui-rework-13 idiom). The bless branch restores the Case with a
-    // routing `CaseBinding { language: "toml", server: "tombi" }` — the
-    // shipped TOML row is dual (taplo primary), and without the reroute an
-    // ambient taplo would satisfy the intentional-diagnostic assertion on
-    // taplo's work, laundering the exact evidence the job exists to produce.
+    // tombi reuses the `toml` fixture (same broken.toml that taplo's case
+    // uses). The `CaseBinding` reroutes TOML to tombi specifically — without
+    // it, an ambient taplo would satisfy the intentional-diagnostic assertion
+    // on taplo's work, laundering the exact evidence this job exists to
+    // produce.
+    Case {
+        server: "tombi",
+        fixture: "toml",
+        file: "broken.toml",
+        binding: Some(CaseBinding {
+            language: "toml",
+            server: "tombi",
+            classify: None,
+        }),
+        slow_start: false,
+    },
 ];
 
 /// Finds `case` by server name.


### PR DESCRIPTION
The bless branch from misc 207's recipe (CatenaryInternal), executed by a Sonnet worker 2026-07-21, gate green locally (4025 passed).

Restores the four legs deliberately trimmed from the staging (`763d911`, `382fa13`):

- `[recipe.tombi]` conforms — the interim `conformance = false` removed
- Conformance harness `Case` + taplo-laundering-prevention `CaseBinding` restored
- `[provision.tombi] kind = "linux-recipe"` restored (macOS provisions via the Linux npm recipe)
- `[discipline.tombi]` (pull lane, `advertise_pull_dynamic_registration`) + `[blessed.tombi.{linux-x86_64,macos-arm64}]` rows at 1.2.4
- Dual languages row `["taplo", "tombi"]` — taplo stays query-primary; both feed diagnostics once blessed

Worker catch worth review: the staged commented `[discipline.tombi]` block had one uncommented `single_file` line that TOML silently assigned to `[discipline.taplo]` — harmless in effect (taplo has the single-file evidence) but a latent footgun; now explicit on taplo's block.

**Merge-on-green is the bless** (human act per the misc 207 ruling): the Conformance run on this PR is the evidentiary instrument — its rooted + single-file tombi legs convert the two remaining source-level inferences (wire discipline, null-root serve) into manifest-grade evidence. Then the watch phase; the tombi-primary flip is a later graduation on that evidence.